### PR TITLE
fix: enable save button in any historic commit

### DIFF
--- a/blocklets/ai-studio/src/components/template-form/commits-tip.tsx
+++ b/blocklets/ai-studio/src/components/template-form/commits-tip.tsx
@@ -132,10 +132,10 @@ export function CommitListView({
                 setLoadingItemHash(undefined);
               }
             }}>
-            <ListItemIcon>
+            <ListItemIcon sx={{ minWidth: 0, mr: 1 }}>
               <Box
                 component={Avatar}
-                width={32}
+                width={1}
                 height={32}
                 src={item.commit.author.avatar}
                 did={item.commit.author.did}

--- a/blocklets/ai-studio/src/pages/project/prompt-actions.tsx
+++ b/blocklets/ai-studio/src/pages/project/prompt-actions.tsx
@@ -108,7 +108,7 @@ export function HeaderActions() {
           </span>
         </CommitsTip>
 
-        <SaveButton projectId={projectId} gitRef={gitRef} disabledButton={disabledButton} />
+        <SaveButton projectId={projectId} gitRef={gitRef} disabled={disabledButton} />
 
         <>
           <Tooltip disableInteractive title={t('setting')}>

--- a/blocklets/ai-studio/src/pages/project/save-button.tsx
+++ b/blocklets/ai-studio/src/pages/project/save-button.tsx
@@ -44,16 +44,16 @@ export interface CommitForm {
 export default function SaveButton({
   projectId,
   gitRef,
-  disabledButton,
+  disabled,
 }: {
   projectId: string;
   gitRef: string;
-  disabledButton?: boolean;
+  disabled?: boolean;
 }) {
   const { t } = useLocaleContext();
   const dialogState = usePopupState({ variant: 'dialog' });
   const [loading, setLoading] = useState(false);
-  const { disabled } = useAssistantChangesState(projectId, gitRef);
+  const { disabled: disabledButton } = useAssistantChangesState(projectId, gitRef);
   const form = useForm<CommitForm>({});
   const submitting = form.formState.isSubmitting || loading;
 
@@ -63,7 +63,7 @@ export default function SaveButton({
         <span>
           <Button
             {...bindTrigger(dialogState)}
-            disabled={disabledButton !== undefined ? disabledButton : submitting || disabled}
+            disabled={disabled ?? (submitting || disabledButton)}
             sx={{
               position: 'relative',
               minWidth: 0,


### PR DESCRIPTION
### 关联 Issue
https://community.arcblock.io/discussions/8ff7b264-144d-4e45-8467-18636b260c48

<!-- 请用 fixes、closes、resolves、relates 这些关键词来关联 issue，原则上，所有 PR 都应该有关联 Issue -->

### 主要改动
当选择历史提交时，可以单击save按钮
<!--
  @example:
    1. 修复了 xxx
    2. 改进了 xxx
    3. 调整了 xxx
-->

### 界面截图
![image](https://github.com/blocklet/ai-studio/assets/11629887/3ab4a7be-444e-4743-939c-a03de30c0bdc)

<!-- 如果改动的是跟 UI 相关的，不论是 CLI 还是 WEB 都应该截图 -->

### 测试计划

<!-- 如果本次变更没有自动化测试覆盖，你整理的测试用例集是什么？需要编写成 todo list 放到下面 -->