### PR TITLE
fix: conditionally render ActionRefOutput for call assistants

### DIFF
--- a/blocklets/ai-studio/src/components/file-editor/output/AddOutputVariableButton.tsx
+++ b/blocklets/ai-studio/src/components/file-editor/output/AddOutputVariableButton.tsx
@@ -1,6 +1,11 @@
 import PopperMenu from '@app/components/menu/PopperMenu';
 import { useLocaleContext } from '@arcblock/ux/lib/Locale/context';
-import { AssistantYjs, OutputVariableYjs, variableBlockListForAgent } from '@blocklet/ai-runtime/types';
+import {
+  AssistantYjs,
+  OutputVariableYjs,
+  isCallAssistant,
+  variableBlockListForAgent,
+} from '@blocklet/ai-runtime/types';
 import { Icon } from '@iconify-icon/react';
 import CheckIcon from '@iconify-icons/tabler/check';
 import BranchIcon from '@iconify-icons/tabler/git-branch';
@@ -148,7 +153,7 @@ export default function AddOutputVariableButton({
         </>
       )}
 
-      <ActionRefOutput projectId={projectId} gitRef={gitRef} assistant={assistant} />
+      {isCallAssistant(assistant) && <ActionRefOutput projectId={projectId} gitRef={gitRef} assistant={assistant} />}
 
       <Divider sx={{ my: '4px !important', p: 0 }} />
 


### PR DESCRIPTION
### 关联 Issue

<!-- 请用 fixes、closes、resolves、relates 这些关键词来关联 issue，原则上，所有 PR 都应该有关联 Issue -->

### 主要改动
1. 修复：call agent 输出选项仅在 call agent block 显示
<!--
  @example:
    1. 修复了 xxx
    2. 改进了 xxx
    3. 调整了 xxx
-->

### 界面截图
<img width="896" alt="image" src="https://github.com/user-attachments/assets/a4f4bc5d-4640-4d7e-b3fd-5f9e86ad3b39" />

<!-- 如果改动的是跟 UI 相关的，不论是 CLI 还是 WEB 都应该截图 -->

### 测试计划

<!-- 如果本次变更没有自动化测试覆盖，你整理的测试用例集是什么？需要编写成 todo list 放到下面 -->

### 检查清单

- [x] 本次变更的兼容性测试覆盖了 Chrome
- [ ] (merge master 前检测) 成功 pnpm dev, pnpm bundle, pnpm bump-version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化了组件显示逻辑：当检测到正在使用智能助手呼叫时，界面会显示额外的输出信息，确保用户仅在适当场景下看到相关内容，从而提升应用界面交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->